### PR TITLE
Add more option to app configuration

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -1,17 +1,25 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 # Metadata defining the behaviour and requirements for this engine
 
 # expected fields in the configuration file for this engine
 configuration:
+  default_type:
+    type: str
+    default_value: ""
+    description: Ticket type by default.
+  default_priority:
+    type: str
+    default_value: "3"
+    description: Tikect priority by default.
   cc:
     type: str
     default_value: ""
@@ -29,14 +37,14 @@ configuration:
                  be included. Set this field to empty string to get all the
                  environment variables
 
-# this app works in all engines - it does not contain 
+# this app works in all engines - it does not contain
 # any host application specific commands
-supported_engines: 
+supported_engines:
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:
-        
-# More verbose description of this item 
+
+# More verbose description of this item
 display_name: "Shotgun Toolkit Bug Reporter"
 description: "An App that can be used to quickly submit a new bug ticket to the support team."
 
@@ -48,4 +56,3 @@ requires_engine_version:
 # the frameworks required to run this app
 frameworks:
   - {"name": "tk-framework-qtwidgets", "version": "v2.x.x", "minimum_version": "v2.7.0"}
-    

--- a/info.yml
+++ b/info.yml
@@ -12,6 +12,12 @@
 
 # expected fields in the configuration file for this engine
 configuration:
+  project_id:
+    type: int
+    default_value: 0
+    description: Define which project the ticket is going to be submited to
+                 If it is 0, submit the ticket to the project of
+                 current context.
   default_type:
     type: str
     default_value: ""

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
@@ -66,7 +66,7 @@ class AppDialog(QtGui.QWidget):
         # via the self._app handle we can for example access:
         # - The engine, via self._app.engine
         # - A Shotgun API instance, via self._app.shotgun
-        # - A tk API instance, via self._app.tk 
+        # - A tk API instance, via self._app.tk
         self.ui.buttons.accepted.connect(self.create_ticket)
         self.ui.buttons.rejected.connect(self.close)
         self.ui.screen_grab.clicked.connect(self.screen_grab)
@@ -212,10 +212,11 @@ class AppDialog(QtGui.QWidget):
             ticket_body += "\n### Environment Variable\n{}".format(env_info)
 
         try:
+            facility_project = {'type': 'Project', 'id': 143}
             result = self._app.shotgun.create(
                 "Ticket",
                 dict(
-                    project=self._app.context.project,
+                    project=facility_project,
                     title=ticket_title,
                     description=ticket_body,
                     addressings_cc=self._cc_widget.get_value(),

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -214,10 +214,9 @@ class AppDialog(QtGui.QWidget):
             ticket_body += "\n### Environment Variable\n{}".format(env_info)
 
         try:
-            if self._app.get_setting("project_id", ""):
-                project_id = self._app.get_setting("project_id", "")
-                project = {'type': 'Project', 'id': project_id}
-            else:
+            project_id = self._app.get_setting("project_id", "")
+            project = {'type': 'Project', 'id': project_id}
+            if not project_id:
                 project = self._app.context.project
             result = self._app.shotgun.create(
                 "Ticket",

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -158,8 +158,10 @@ class AppDialog(QtGui.QWidget):
         self.ui.priority_layout.addWidget(self._ticket_priority_widget)
 
         # Setting defaults
-        self._ticket_type_widget.set_value("Bug")
-        self._ticket_priority_widget.set_value(5)
+        type_default = self._app.get_setting("default_type", "")
+        priority_default = self._app.get_setting("default_priority", "")
+        self._ticket_type_widget.set_value(type_default)
+        self._ticket_priority_widget.set_value(priority_default)
 
     def screen_grab(self):
         """

--- a/python/app/dialog.py
+++ b/python/app/dialog.py
@@ -159,8 +159,8 @@ class AppDialog(QtGui.QWidget):
 
         # Setting defaults
         type_default = self._app.get_setting("default_type", "")
-        priority_default = self._app.get_setting("default_priority", "")
         self._ticket_type_widget.set_value(type_default)
+        priority_default = self._app.get_setting("default_priority", "")
         self._ticket_priority_widget.set_value(priority_default)
 
     def screen_grab(self):
@@ -214,11 +214,15 @@ class AppDialog(QtGui.QWidget):
             ticket_body += "\n### Environment Variable\n{}".format(env_info)
 
         try:
-            facility_project = {'type': 'Project', 'id': 143}
+            if self._app.get_setting("project_id", ""):
+                project_id = self._app.get_setting("project_id", "")
+                project = {'type': 'Project', 'id': project_id}
+            else:
+                project = self._app.context.project
             result = self._app.shotgun.create(
                 "Ticket",
                 dict(
-                    project=facility_project,
+                    project=project,
                     title=ticket_title,
                     description=ticket_body,
                     addressings_cc=self._cc_widget.get_value(),


### PR DESCRIPTION
To make it more flexible for different studio setups, I added following field to app configuration:
- **project_id**, if users want all tickets submit to a centralized project(facility project, software dev project, etc), they can define the project id in configuration.
- **default_type**, ticket type by default.
- **default_priority**, ticket priority by default.

Also delete some trailing spaces.